### PR TITLE
Use GitHub's runner for Pages action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,18 +18,20 @@ concurrency:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v3
     - name: Get Dependencies
-      run: docker images | grep jekyll-app >/dev/null || docker build . -t jekyll-app
-    - name: Prep Artifacts dir
-      run: mkdir -p public && chmod 777 public
+      run: apt install ruby-full build-essential zlib1g-dev
+    - name: Get Jekyll
+      run: |
+              export GEM_HOME="$HOME/gems"
+              export PATH="$HOME/gems/bin:$PATH"
+              gem install jekyll bundler
+              bundle install
     - name: Build Artifacts
-      run: docker run --volume="$(pwd):/app" jekyll-app:latest jekyll build -d public
-    - name: Modify Permissions for Cleanup
-      run: docker run --volume="$(pwd):/app" jekyll-app:latest chmod -R 777 public
+      run: bundle exec jekyll build -d public
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Ruby Cache
       uses: ruby/setup-ruby@v1
       with:
+        ruby-version: 3.1.1
         bundler-cache: true
     - name: Get Jekyll
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
     - name: Get Dependencies
-      run: apt install ruby-full build-essential zlib1g-dev
+      run: sudo apt install ruby-full build-essential zlib1g-dev -y
     - name: Get Jekyll
       run: |
               export GEM_HOME="$HOME/gems"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Get Dependencies
       run: sudo apt-get install ruby-full build-essential zlib1g-dev -y
     - name: Get Jekyll
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
       run: |
               export GEM_HOME="$HOME/gems"
               export PATH="$HOME/gems/bin:$PATH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,11 @@ jobs:
       uses: actions/checkout@v3
     - name: Get Dependencies
       run: sudo apt-get install ruby-full build-essential zlib1g-dev -y
-    - name: Get Jekyll
+    - name: Ruby Cache
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+    - name: Get Jekyll
       run: |
               export GEM_HOME="$HOME/gems"
               export PATH="$HOME/gems/bin:$PATH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,10 @@ jobs:
               gem install jekyll bundler
               bundle install
     - name: Build Artifacts
-      run: bundle exec jekyll build -d public
+      run: |
+              export GEM_HOME="$HOME/gems"
+              export PATH="$HOME/gems/bin:$PATH"
+              bundle exec jekyll build -d public
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
     - name: Get Dependencies
-      run: sudo apt install ruby-full build-essential zlib1g-dev -y
+      run: sudo apt-get install ruby-full build-essential zlib1g-dev -y
     - name: Get Jekyll
       run: |
               export GEM_HOME="$HOME/gems"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,8 @@ jobs:
       with:
         ruby-version: 3.1.1
         bundler-cache: true
-    - name: Get Jekyll
-      run: |
-              export GEM_HOME="$HOME/gems"
-              export PATH="$HOME/gems/bin:$PATH"
-              gem install jekyll bundler
-              bundle install
     - name: Build Artifacts
-      run: |
-              export GEM_HOME="$HOME/gems"
-              export PATH="$HOME/gems/bin:$PATH"
-              bundle exec jekyll build -d public
+      run: bundle exec jekyll build -d public
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:


### PR DESCRIPTION
While GitHub's runners are somewhat limited, they are preferred to self-hosting runners. Self-hosting requires an additional resource that may not be available as people move and leave.

Instead we can use GitHub runners and just accept the extra compute time when it fetches and installs ruby and jekyll. 